### PR TITLE
Try the svn2git using subgit

### DIFF
--- a/difx-subgit/README.md
+++ b/difx-subgit/README.md
@@ -1,0 +1,116 @@
+# Introduction
+
+Here is some steps for the migration of DiFX from SVN to GIT.
+
+## Download subgit
+
+Goto https://subgit.com/ to get the latest version of subgit.
+
+## Try-1
+
+
+### Configure Mirror Git Repository
+
+As there was no trunk of DiFX, so you should point the `--trunk` parameter for the running.
+
+```bash
+$ ~/subgit-3.3.10/bin/subgit configure --layout auto --trunk virtualtrunk --svn-url https://svn.atnf.csiro.au/difx
+
+SubGit version 3.3.10 ('Bobique') build #4368
+
+Configuring writable Git mirror of remote Subversion repository:
+    Subversion repository URL : https://svn.atnf.csiro.au/difx
+    Git repository location   : difx.git
+
+Peg location detected: r9745 virtualtrunk
+Fetching SVN history... Done.
+Growing trees... Done.
+Project origin detected: r5674 virtualtrunk
+Building branches layouts... Done.
+Combing beards... Done.
+Generating SVN to Git mapping... Done.
+
+CONFIGURATION SUCCESSFUL
+
+To complete SubGit installation do the following:
+
+1) Adjust Subversion to Git branches mapping if necessary:
+    ~/DiFX-test/difx.git/subgit/config
+2) Define at least one Subversion credentials in default SubGit passwd file at:
+    ~/DiFX-test/difx.git/subgit/passwd
+   OR configure SSH or SSL credentials in the [auth] section of:
+    ~/DiFX-test/difx.git/subgit/config
+3) Optionally, add custom authors mapping to the authors.txt file(s) at:
+    ~/DiFX-test/difx.git/subgit/authors.txt
+4) Run SubGit 'install' command:
+    subgit install difx.git
+```
+
+### Review and Adjust Git/SVN Mirror Configuration
+
+```bash
+$ vim difx.git/subgit/config
+$ vim difx.git/subgit/authors.txt
+```
+
+### Begin translation
+
+```bash
+$ ~/subgit-3.3.10/bin/subgit install difx.git
+
+SubGit version 3.3.10 ('Bobique') build #4368
+
+Translating Subversion revisions to Git commits...
+
+    Subversion revisions translated: 9745.
+    Total time: 242 seconds.
+
+INSTALLATION SUCCESSFUL
+```
+
+In this way, I just got 21 commits with no tags.
+
+## Try-2
+
+```bash
+$ ../subgit-3.3.10/bin/subgit configure --trunk virtualtrunk   --svn-url https://svn.atnf.csiro.au/difx difx2.git
+SubGit version 3.3.10 ('Bobique') build #4368
+
+Configuring writable Git mirror of remote Subversion repository:
+    Subversion repository URL : https://svn.atnf.csiro.au/difx
+    Git repository location   : difx2.git
+
+CONFIGURATION SUCCESSFUL
+
+To complete SubGit installation do the following:
+
+1) Adjust Subversion to Git branches mapping if necessary:
+    ~/DiFX-test/difx2.git/subgit/config
+2) Define at least one Subversion credentials in default SubGit passwd file at:
+    ~/DiFX-test/difx2.git/subgit/passwd
+   OR configure SSH or SSL credentials in the [auth] section of:
+    ~/DiFX-test/difx2.git/subgit/config
+    # Here modify the config file as following:
+    
+3) Optionally, add custom authors mapping to the authors.txt file(s) at:
+    ~/DiFX-test/difx2.git/subgit/authors.txt
+4) Run SubGit 'install' command:
+    subgit install difx2.git
+
+$ ../subgit-3.3.10/bin/subgit install difx2.git
+
+SubGit version 3.3.10 ('Bobique') build #4368
+
+Translating Subversion revisions to Git commits...
+
+    Subversion revisions translated: 9745.
+    Total time: 3251 seconds.
+
+INSTALLATION SUCCESSFUL
+```
+
+In this way, I just got 21 commits with 13 tags.
+
+## Try - 3
+
+git svn clone https://svn.atnf.csiro.au/difx --authors-file=authors.txt

--- a/difx-subgit/authors.txt
+++ b/difx-subgit/authors.txt
@@ -1,0 +1,38 @@
+#
+# This is SubGit authors mapping file.
+# Authors mapping is used to map Subversion committers names to Git committers names and vice versa.
+#
+# This file uses git-svn format, as described at 'http://www.kernel.org/pub/software/scm/git/docs/git-svn.html'
+# and consists of the lines in the following format:
+#
+# svnUser = Git User <user@example.com>
+# 
+
+
+AdamDeller = adamdeller <adeller@swin.edu.au>
+CherieDay = CherieDay <cday@swin.edu.au>
+ChrisPhillips = XhrisPhillips <Chris.Phillips@csiro.au>
+CormacReynolds = CormacReynolds <Cormac.Reynolds@csiro.au>
+DavidGordon = DavidGordon <david.gordon-1@nasa.gov>
+FredericJaron = FredericJaron <FredericJaron@example.com>
+GeoffreyCrew = GeoffreyCrew <gbc@haystack.mit.edu>
+HelgeRottmann = HelgeRottmann <rottmann@mpifr-bonn.mpg.de>
+JamesAnderson = JamesAnderson <jamesanderson@domain.com>
+JanWagner = jwagnerhki <jan.wagner@iki.fi>
+JimJacobs = JimJacobs <jjacobs@nrao.edu>
+JohnBarrett = JohnBarrett <barrettj@mit.edu>
+JohnMorgan = JohnMorgan <mojoh81@gmail.com>
+JohnSpitzak = JohnSpitzak <john.spitzak.ctr@usno.navy.mil>
+LeonidPetrov = LeonidPetrov <LeonidPetrov@atnf.csiro.au>
+MahmoudMahmoud = MahmoudMahmoud <MahmoudMahmoud@example.com>
+MarkWainright = MarkWainright <MarkWainright@atnf.csiro.au>
+MatthiasBark = MatthiasBark <matthiasbark@domain.com>
+MichaelDutka = MichaelDutka <MichaelDutka@atnf.csiro.au>
+NicolasPradel = NicolasPradel <septimussonh@gmail.com>
+RandallWayth = RandallWayth <R.Wayth@curtin.edu.au>
+RichardDodson = RichardDodson <richard.dodson@uwa.edu.au>
+RogerCappallo = RogerCappallo <roger.cappallo@gmail.com>
+TonyMaher = TonyMaher <tonymaher@domain.com>
+WalterAlef = WalterAlef <alef@mpifr-bonn.mpg.de>
+WalterBrisken = WalterBrisken <wbrisken@aoc.nrao.edu>
+ZhengMeyerZhao = zhengmeyer <zhengmeyerzhao@domain.com>

--- a/difx-subgit/subgit1/config
+++ b/difx-subgit/subgit1/config
@@ -1,0 +1,235 @@
+# This is SubGit configuration file.
+#
+# SubGit is a tool for instant and transparent SVN/Git synchronization.
+#
+# Please visit http://www.subgit.com/ for more information on SubGit,
+# new versions and online support.
+
+#
+# General options
+#
+[core]
+	# When core.shared is set to 'true', all files will be made group-writable.
+	#
+	# You MUST set this option to 'true' when more than one system account is used
+	# to work with this repository (e.g. Apache for Subversion and SSH for Git).
+	# All these accounts MUST then share the same primary group.
+	shared = false
+
+	# Path to the directory where logs are stored.
+	logs = subgit/logs
+
+	# Path to the authors mapping file or authors mapping helper program.
+	#
+	# There could be one or more authorsFile options specified. Options are processed
+	# from the last to the first one specifed, until mapping is obtained.
+	#
+	# Option value could be one of the following:
+	#
+	#        text file with explicit authors mapping in git-svn format,
+	#        that is described at 'http://www.kernel.org/pub/software/scm/git/docs/git-svn.html'
+	#     OR
+	#        path to an executable authors mapping helper program and its optional arguments;
+	#        authors mapping helper program is expected to read data from the standard input
+	#        and to provide output to the standard output. Input/output format is:
+	#
+	#        for Git to Subversion mapping:
+	#               INPUT:
+	#                FULL AUTHOR NAME
+	#                AUTHOR EMAIL
+	#               OUTPUT:
+	#                SUBVERSION USER NAME
+	#
+	#        for Subversion to Git mapping:
+	#               INPUT:
+	#                SUBVERSION USER NAME
+	#               OUTPUT:
+	#                FULL AUTHOR NAME
+	#                AUTHOR EMAIL
+	#
+	#        Sample authors mapping script could be found in 'subgit/samples' directory.
+	#
+	# When no authorsFile option is specified, automatically generated mapping will be used.
+	authorsFile = subgit/authors.txt
+
+	# Encoding to be used in the authors mapping file.
+	authorsFileEncoding = UTF-8
+
+	# Domain to be used to generate Git committer email when authors mapping
+	# is not defined or does not provide email address for a particular committer.
+	defaultDomain = domain
+
+	# Encoding to be used to store paths in Git tree objects.
+	pathEncoding = UTF-8
+
+#
+# Subversion to Git mapping options
+#
+[svn]
+	# Subversion repository URL
+	url = https://svn.atnf.csiro.au/difx
+
+	# Options below (trunk, branches, tags, shelves) define correspondece between Subversion
+	# directories and Git references. Depending on the actual Subversion project layout and whether
+	# all or only some of the branches have to be mirrored, these options might need to be adjusted.
+	#
+	#  Generic mapping syntax is:
+	#    <Subversion-Path-Pattern>:<Git-Reference-Pattern>
+	#
+	#  Subversion paths are relative to the URL defined by the svn.url option.
+	#
+	#  Wildcard mappings:
+	#    Use wildcard branches and tags mappings to define correspondence between set of Subversion
+	#    directories that represent branches or tags and corresponding Git references:
+	#
+	#    branches = branches/*:refs/heads/*
+	#    branches = branches/*/*:refs/heads/*/*
+	#    branches = branches/*/project:refs/heads/*
+	#    branches = branches/feature_*_2015:refs/heads/features/*
+	#
+	#    Wildcard related mapping syntax rules:
+	#
+	#    - Each mapping could include zero or more '*' on both sides (sides are separated by ':') of the definition.
+	#    - Each path or namespace segment should contain no more than one '*'.
+	#    - Number of '*' on the left side of the mapping must be equal to the number of '*' on the right side of it.
+	#
+	#  Explicit mappings:
+	#    Use explicit mapping for the Subversion directory that represents trunk and optionally for
+	#    individual branches or tags:
+	#
+	#    trunk = trunk:refs/heads/master
+	#    branches = branches/1.0.x:refs/heads/1.0.x
+	#    tags = tags/1.0.1:refs/tags/1.0.1
+	#
+	#  Shelves:
+	#    Shelves are special branches SubGit creates in Subversion repository to mirror Git anonymous
+	#    branches to. Shelves mapping is optional, when unspecified anonymous Git branches will not
+	#    be mirrored. shelves option defines location for those special branches:
+	#
+	#    shelves = shelves/*:refs/shelves/*
+	#
+	#  Excluding branches, tags and paths from translaiton:
+	#     Mappings could be refined by specifying patterns that controls what branches and tags
+	#     are excluded from the translation.
+	#
+	#     excludeBranches = SIMPLE_PATTERN
+	#
+	#     Value of excludeBranches option is simple path matching pattern, with zero or one '*' symbol.
+	#     Branch path relative to the Subversion project URL is matched against the pattern specified.
+	#
+	#     To include or exclude particular files or directories within any of the branches or tags,
+	#     use the following options:
+	#
+	#     excludePath = PATTERN
+	#     includePath = PATTERN
+	#
+	#     Value of excludePath and includePath options is a pattern in format same to that used in .gitignore file.
+	#     Only non-recursive patterns are supported by includePath option (pattern should start with '/').
+	#     Paths being matched against the patterns are relative to the branch or tag path.
+	#     See 'http://git-scm.com/docs/gitignore' for complete documentation on the pattern format.
+	#
+	#     When branches, tags or paths are excluded from the translation with the help of one of the above options,
+	#     modifications to those branches or paths made in Subversion project would not be translated to Git,
+	#     as well as changes in Git repository made to those locations would not appear in Subversion.
+	#
+	# SubGit supports mirroring of Subversion projects that have no branches. To configure mirror
+	# for such project do the following:
+	#
+	#    a) Define no mapping (no trunk, branches, tags and shelves options), and
+	#       make sure that svn.url option value refers to the project root folder
+	#       in Subversion repository;
+	#    b) optionally set trunk = :refs/heads/referenceName to override default Git branch name.
+	#
+	# Paths in mappings are case-sensitive, i.e. trunk and Trunk are considered to be
+	# different paths.
+	#
+	# Once defines, mapping could be extended (e.g. new branches could be added), but changes that
+	# leave existing branches unmapped are not accepted.
+	#
+	# Mapping suggested by default reflects recommended Subversion project layout as described
+	# at 'http://svnbook.red-bean.com/en/1.7/svn.tour.importing.html#svn.tour.importing.layout'
+	trunk = virtualtrunk:refs/heads/master
+	branches = branches/*:refs/heads/*
+	tags = tags/*:refs/tags/*
+	tags = master_tags/DiFX-2.3:refs/tags/master_tags/DiFX-2.3
+	shelves = shelves/*:refs/shelves/*
+
+	# Interval between checks for new changes in Subversion repository in seconds.
+	fetchInterval = 60
+
+	# Subversion connection establishment timeout in seconds.
+	connectTimeout = 300
+
+	# Subversion connection read timeout in seconds.
+	readTimeout = 600
+
+	# enable HTTP requests spooling to prevent server-side timeout when request processing takes long time.
+	httpSpooling = false
+
+	# When 'git.keepGitCommitTime' is set to 'true', SVN commits will have the same dates
+	# as corresponding Git commits, even if this violates monotonic increase of commit dates from revision to revision.
+	# As a side effect some features that rely on dates order like 'revision dates' may work incorrectly
+	# (see 'http://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html' for 'revision dates' feature explanation).
+	#
+	# When 'git.keepGitCommitTime' is set to false, SubGit will try to preserve Git commit dates while translation to SVN,
+	# as it is possible, but it will guarantee SVN dates to increase monotonically from revision to revision.
+	keepGitCommitTime = false
+
+	# Comma-separated list of [auth] sections ids where Subversion credentials are defined.
+	# Credentials will be used both for read-only and write operations, and it is recommended to
+	# define credentials of an account that has full access to the Subversion repository.
+	auth = default
+
+#
+# Subversion authentication options.
+# Valid options in this section are:
+#
+#    passwords: path to the file that contains user/password pairs;
+#
+#    credentialHelper: path to the credential helper program and its optional arguments;
+#                      program is expected to be non-interactive (no prompt) and
+#                      to use Git credential helper input/output format;
+#                      refer to 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html#IOFMT' for more details;
+#
+#                      Sample credential helper script could be found in 'subgit/samples' directory.
+#
+#    userName: user name to use to log into Subversion repository;
+#
+#    password: password to use with the explicitly specified user name;
+#
+#    sshKeyFile: for svn+ssh protocol, SSH private key to use; OpenSSH format is supported;
+#    sshKeyFilePassphrase: passphrase to use to read SSH private key;
+#
+#    sslClientCertFile: for SSL protocol, client SSL client certificate to use; PKSC#12 format is supported;
+#    sslClientCertPassphrase: passphrase to use to read SSL client certificate;
+#
+#    subversionConfigurationDirectory: path to Subversion configuration directory or '@default@' to use
+#                                      current user Subversion configuration and credentials cache.
+#
+[auth "default"]
+	# Passwords file path. Passwords file contains user name/password pairs that should be
+	# used to log into Subversion repository.
+	passwords = subgit/passwd
+	useDefaultSubversionConfigurationDirectory = false
+	subversionConfigurationDirectory = /Users/leo/.subversion
+
+#
+# Options specific to the background translation process.
+#
+[daemon]
+	# Pid file path.
+	pidFile = subgit/daemon.pid
+
+	# Timeout in seconds; background translation process exits
+	# after being idle for the specified amount of seconds.
+	#
+	# 0 seconds timeout means that translation process exits immediately.
+	#
+	# Larger timeout values may improve translation performance by reducing
+	# translation process startup overhead.
+	idleTimeout = infinity
+
+	# Explicit translation process classpath or path to the directory
+	# that contains jars that have to be on the process classpath.
+	classpath = subgit/lib
+

--- a/difx-subgit/subgit2/config
+++ b/difx-subgit/subgit2/config
@@ -1,0 +1,243 @@
+# This is SubGit configuration file.
+#
+# SubGit is a tool for instant and transparent SVN/Git synchronization.
+#
+# Please visit http://www.subgit.com/ for more information on SubGit,
+# new versions and online support.
+
+#
+# General options
+#
+[core]
+	# When core.shared is set to 'true', all files will be made group-writable.
+	#
+	# You MUST set this option to 'true' when more than one system account is used
+	# to work with this repository (e.g. Apache for Subversion and SSH for Git).
+	# All these accounts MUST then share the same primary group.
+	shared = false
+
+	# Path to the directory where logs are stored.
+	logs = subgit/logs
+
+	# Path to the authors mapping file or authors mapping helper program.
+	#
+	# There could be one or more authorsFile options specified. Options are processed
+	# from the last to the first one specifed, until mapping is obtained.
+	#
+	# Option value could be one of the following:
+	#
+	#        text file with explicit authors mapping in git-svn format,
+	#        that is described at 'http://www.kernel.org/pub/software/scm/git/docs/git-svn.html'
+	#     OR
+	#        path to an executable authors mapping helper program and its optional arguments;
+	#        authors mapping helper program is expected to read data from the standard input
+	#        and to provide output to the standard output. Input/output format is:
+	#
+	#        for Git to Subversion mapping:
+	#               INPUT:
+	#                FULL AUTHOR NAME
+	#                AUTHOR EMAIL
+	#               OUTPUT:
+	#                SUBVERSION USER NAME
+	#
+	#        for Subversion to Git mapping:
+	#               INPUT:
+	#                SUBVERSION USER NAME
+	#               OUTPUT:
+	#                FULL AUTHOR NAME
+	#                AUTHOR EMAIL
+	#
+	#        Sample authors mapping script could be found in 'subgit/samples' directory.
+	#
+	# When no authorsFile option is specified, automatically generated mapping will be used.
+	authorsFile = subgit/authors.txt
+
+	# Encoding to be used in the authors mapping file.
+	authorsFileEncoding = UTF-8
+
+	# Domain to be used to generate Git committer email when authors mapping
+	# is not defined or does not provide email address for a particular committer.
+	defaultDomain = domain
+
+	# Encoding to be used to store paths in Git tree objects.
+	pathEncoding = UTF-8
+
+#
+# Subversion to Git mapping options
+#
+[svn]
+	# Subversion repository URL
+	url = https://svn.atnf.csiro.au/difx
+
+	# Options below (trunk, branches, tags, shelves) define correspondece between Subversion
+	# directories and Git references. Depending on the actual Subversion project layout and whether
+	# all or only some of the branches have to be mirrored, these options might need to be adjusted.
+	#
+	#  Generic mapping syntax is:
+	#    <Subversion-Path-Pattern>:<Git-Reference-Pattern>
+	#
+	#  Subversion paths are relative to the URL defined by the svn.url option.
+	#
+	#  Wildcard mappings:
+	#    Use wildcard branches and tags mappings to define correspondence between set of Subversion
+	#    directories that represent branches or tags and corresponding Git references:
+	#
+	#    branches = branches/*:refs/heads/*
+	#    branches = branches/*/*:refs/heads/*/*
+	#    branches = branches/*/project:refs/heads/*
+	#    branches = branches/feature_*_2015:refs/heads/features/*
+	#
+	#    Wildcard related mapping syntax rules:
+	#
+	#    - Each mapping could include zero or more '*' on both sides (sides are separated by ':') of the definition.
+	#    - Each path or namespace segment should contain no more than one '*'.
+	#    - Number of '*' on the left side of the mapping must be equal to the number of '*' on the right side of it.
+	#
+	#  Explicit mappings:
+	#    Use explicit mapping for the Subversion directory that represents trunk and optionally for
+	#    individual branches or tags:
+	#
+	#    trunk = trunk:refs/heads/master
+	#    branches = branches/1.0.x:refs/heads/1.0.x
+	#    tags = tags/1.0.1:refs/tags/1.0.1
+	#
+	#  Shelves:
+	#    Shelves are special branches SubGit creates in Subversion repository to mirror Git anonymous
+	#    branches to. Shelves mapping is optional, when unspecified anonymous Git branches will not
+	#    be mirrored. shelves option defines location for those special branches:
+	#
+	#    shelves = shelves/*:refs/shelves/*
+	#
+	#  Excluding branches, tags and paths from translaiton:
+	#     Mappings could be refined by specifying patterns that controls what branches and tags
+	#     are excluded from the translation.
+	#
+	#     excludeBranches = SIMPLE_PATTERN
+	#
+	#     Value of excludeBranches option is simple path matching pattern, with zero or one '*' symbol.
+	#     Branch path relative to the Subversion project URL is matched against the pattern specified.
+	#
+	#     To include or exclude particular files or directories within any of the branches or tags,
+	#     use the following options:
+	#
+	#     excludePath = PATTERN
+	#     includePath = PATTERN
+	#
+	#     Value of excludePath and includePath options is a pattern in format same to that used in .gitignore file.
+	#     Only non-recursive patterns are supported by includePath option (pattern should start with '/').
+	#     Paths being matched against the patterns are relative to the branch or tag path.
+	#     See 'http://git-scm.com/docs/gitignore' for complete documentation on the pattern format.
+	#
+	#     When branches, tags or paths are excluded from the translation with the help of one of the above options,
+	#     modifications to those branches or paths made in Subversion project would not be translated to Git,
+	#     as well as changes in Git repository made to those locations would not appear in Subversion.
+	#
+	# SubGit supports mirroring of Subversion projects that have no branches. To configure mirror
+	# for such project do the following:
+	#
+	#    a) Define no mapping (no trunk, branches, tags and shelves options), and
+	#       make sure that svn.url option value refers to the project root folder
+	#       in Subversion repository;
+	#    b) optionally set trunk = :refs/heads/referenceName to override default Git branch name.
+	#
+	# Paths in mappings are case-sensitive, i.e. trunk and Trunk are considered to be
+	# different paths.
+	#
+	# Once defines, mapping could be extended (e.g. new branches could be added), but changes that
+	# leave existing branches unmapped are not accepted.
+	#
+	# Mapping suggested by default reflects recommended Subversion project layout as described
+	# at 'http://svnbook.red-bean.com/en/1.7/svn.tour.importing.html#svn.tour.importing.layout'
+	trunk = virtualtrunk:refs/heads/master
+	branches = branches/*:refs/heads/*
+	branches = applications:refs/heads/applications
+	branches = doc:refs/heads/doc
+	branches = libraries:refs/heads/libraries
+	branches = mpifxcorr:refs/heads/mpifxcorr
+	branches = setup:refs/heads/setup
+	branches = sites:refs/heads/sites
+	branches = tests:refs/heads/tests
+	branches = utilities:refs/heads/utilities
+	branches = deprecated:refs/heads/deprecated
+	tags = master_tags/*:refs/tags/*
+	shelves = shelves/*:refs/shelves/*
+
+	# Interval between checks for new changes in Subversion repository in seconds.
+	fetchInterval = 60
+
+	# Subversion connection establishment timeout in seconds.
+	connectTimeout = 300
+
+	# Subversion connection read timeout in seconds.
+	readTimeout = 600
+
+	# enable HTTP requests spooling to prevent server-side timeout when request processing takes long time.
+	httpSpooling = false
+
+	# When 'git.keepGitCommitTime' is set to 'true', SVN commits will have the same dates
+	# as corresponding Git commits, even if this violates monotonic increase of commit dates from revision to revision.
+	# As a side effect some features that rely on dates order like 'revision dates' may work incorrectly
+	# (see 'http://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html' for 'revision dates' feature explanation).
+	#
+	# When 'git.keepGitCommitTime' is set to false, SubGit will try to preserve Git commit dates while translation to SVN,
+	# as it is possible, but it will guarantee SVN dates to increase monotonically from revision to revision.
+	keepGitCommitTime = false
+
+	# Comma-separated list of [auth] sections ids where Subversion credentials are defined.
+	# Credentials will be used both for read-only and write operations, and it is recommended to
+	# define credentials of an account that has full access to the Subversion repository.
+	auth = default
+
+#
+# Subversion authentication options.
+# Valid options in this section are:
+#
+#    passwords: path to the file that contains user/password pairs;
+#
+#    credentialHelper: path to the credential helper program and its optional arguments;
+#                      program is expected to be non-interactive (no prompt) and
+#                      to use Git credential helper input/output format;
+#                      refer to 'https://www.kernel.org/pub/software/scm/git/docs/git-credential.html#IOFMT' for more details;
+#
+#                      Sample credential helper script could be found in 'subgit/samples' directory.
+#
+#    userName: user name to use to log into Subversion repository;
+#
+#    password: password to use with the explicitly specified user name;
+#
+#    sshKeyFile: for svn+ssh protocol, SSH private key to use; OpenSSH format is supported;
+#    sshKeyFilePassphrase: passphrase to use to read SSH private key;
+#
+#    sslClientCertFile: for SSL protocol, client SSL client certificate to use; PKSC#12 format is supported;
+#    sslClientCertPassphrase: passphrase to use to read SSL client certificate;
+#
+#    subversionConfigurationDirectory: path to Subversion configuration directory or '@default@' to use
+#                                      current user Subversion configuration and credentials cache.
+#
+[auth "default"]
+	# Passwords file path. Passwords file contains user name/password pairs that should be
+	# used to log into Subversion repository.
+	passwords = subgit/passwd
+	useDefaultSubversionConfigurationDirectory = false
+	subversionConfigurationDirectory = /Users/leo/.subversion
+
+#
+# Options specific to the background translation process.
+#
+[daemon]
+	# Pid file path.
+	pidFile = subgit/daemon.pid
+
+	# Timeout in seconds; background translation process exits
+	# after being idle for the specified amount of seconds.
+	#
+	# 0 seconds timeout means that translation process exits immediately.
+	#
+	# Larger timeout values may improve translation performance by reducing
+	# translation process startup overhead.
+	idleTimeout = infinity
+
+	# Explicit translation process classpath or path to the directory
+	# that contains jars that have to be on the process classpath.
+	classpath = subgit/lib
+


### PR DESCRIPTION
@wumpus  I've used subgit to try the git migration.
Looks like I retrive all the commits during the procssing(See the difx-subgit/README.md).

But after I push to the [repo](https://github.com/difx-migration/difx-subgit), I just got 21 commits and 14 tags. 

I will try this unless you decided we will choose the plan supported by you.

And also, you can put authors.txt on the top level, I've collect most DiFX developers except several. 